### PR TITLE
Rework encrypt/decrypt API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,70 @@ supported through modern Python versions.
 [PyCrypto]: https://github.com/pycrypto/pycrypto/commit/65b43bd4ffe2a48bdedae986b1a291f5a2cc7df7
 
 [PyCryptodome]: https://pycryptodome.readthedocs.io/en/latest/index.html
+
+## Usage
+
+```lua
+local blowfish = require("blowfish")
+local keychain = blowfish.new(blowfish.MODE_CBC, "some-key", "short-iv")
+local cipher_text = keychain:encrypt("message to encrypt")
+keychain:reset()
+local plain_text = keychange:decrypt(cipher_text)
+print(plain_text)  -- message to encrypt
+```
+
+## API
+
+### blowfish.new
+
+Creates a new context or fail.
+
+| Parameter             | Type   | Description                                                  |
+|-----------------------|--------|--------------------------------------------------------------|
+| mode                  | number | selects the processing mode                                  |
+| key                   | string | encryption key between 4 and 56 bytes                        |
+| initialization vector | string | bytes to mix into the cipher blocks                          |
+| segment size          | number | number of bits in each segment this is only used in CBC mode |
+
+This function fails by calling `error()` with a useful message. Use `pcall()` if you want to
+protect from configuration errors.
+
+### Blowfish:encrypt
+
+Encrypt a string.
+
+| Parameter  | Type   | Description        |
+|------------|--------|--------------------|
+| plain text | string | message to encrypt |
+
+| Return index | Type   | Description                                         |
+|:------------:|--------|-----------------------------------------------------|
+|      1       | string | the ciphertext string or `nil` if an error occurs   |
+|      2       | string | error message if an error occurred, `nil` otherwise |
+
+This method will return `nil` for exactly one of the return slots. If an error occurs, then the first
+slot will be `nil` and the second contains an error message. Otherwise, the first slot is the cipher
+text and the second is `nil`.
+
+### Blowfish:decrypt
+
+Decrypt a string.
+
+| Parameter   | Type   | Description        |
+|-------------|--------|--------------------|
+| cipher text | string | message to decrypt |
+
+| Return index | Type   | Description                                         |
+|:------------:|--------|-----------------------------------------------------|
+|      1       | string | the plaintext string or `nil` if an error occurs    |
+|      2       | string | error message if an error occurred, `nil` otherwise |
+
+This method will return `nil` for exactly one of the return slots. If an error occurs, then the first
+slot will be `nil` and the second contains an error message. Otherwise, the first slot is the decrypted
+text and the second is `nil`.
+
+### Blowfish:reset
+
+Reset a context for additional processing.
+
+This method resets the internal state in preparation to make another call.

--- a/spec/cbc_spec.lua
+++ b/spec/cbc_spec.lua
@@ -86,23 +86,28 @@ describe("#CBC", function()
 
     describe("decryption", function()
         local keychain
+        local value, err
         setup(function() keychain = blowfish.new(MODE, KEY, IV) end)
-        it("returns nil when given an empty string",
-           function() assert.equal(nil, keychain:decrypt("")) end)
+        it("returns nil when given an empty string", function()
+            value, err = keychain:decrypt("")
+            assert.is_nil(value)
+            assert.is_nil(err)
+        end)
         it("fails when given a non-string", function()
-            assert.has.errors(function() keychain:decrypt({}) end)
+            value, err = keychain:decrypt({})
+            assert.is_nil(value)
+            assert.is_not_nil(err)
         end)
         it("requires cipher-text that is multiple of 8 bytes", function()
             local ciphertext = "\0"
             while (#ciphertext <= 64) do
+                value, err = keychain:decrypt(ciphertext)
                 if (#ciphertext % 8 == 0) then
-                    assert.has_no.errors(function()
-                        keychain:decrypt(ciphertext)
-                    end)
+                    assert.is_not_nil(value)
+                    assert.is_nil(err)
                 else
-                    assert.has.errors(function()
-                        keychain:decrypt(ciphertext)
-                    end)
+                    assert.is_nil(value)
+                    assert.is_not_nil(err)
                 end
                 ciphertext = ciphertext .. "\0"
                 keychain:reset()

--- a/spec/cbc_spec.lua
+++ b/spec/cbc_spec.lua
@@ -55,23 +55,28 @@ describe("#CBC", function()
 
     describe("encryption", function()
         local keychain
+        local value, err
         setup(function() keychain = blowfish.new(MODE, KEY, IV) end)
-        it("returns nil when given an empty string",
-           function() assert.equal(nil, keychain:encrypt("")) end)
+        it("returns nil when given an empty string", function()
+            value, err = keychain:encrypt("")
+            assert.is_nil(value)
+            assert.is_nil(err)
+        end)
         it("fails when given a non-string", function()
-            assert.has.errors(function() keychain:encrypt({}) end)
+            value, err = keychain:encrypt({})
+            assert.is_nil(value)
+            assert.is_not_nil(err)
         end)
         it("requires message that is multiple of 8 bytes", function()
             local message = "a"
             while (#message <= 64) do
+                value, err = keychain:encrypt(message)
                 if (#message % 8 == 0) then
-                    assert.has_no.errors(function()
-                        keychain:encrypt(message)
-                    end)
+                    assert.is_not_nil(value)
+                    assert.is_nil(err)
                 else
-                    assert.has.errors(function()
-                        keychain:encrypt(message)
-                    end)
+                    assert.is_nil(value)
+                    assert.is_not_nil(err)
                 end
                 message = message .. "b"
                 keychain:reset()

--- a/spec/cfb_spec.lua
+++ b/spec/cfb_spec.lua
@@ -103,26 +103,31 @@ describe("#CFB", function()
     describe("decryption", function()
         local segment_size = 24
         local keychain
+        local value, err
         setup(function()
             keychain = blowfish.new(MODE, KEY, IV, segment_size)
         end)
-        it("returns nil when given an empty string",
-           function() assert.equal(nil, keychain:decrypt("")) end)
+        it("returns nil when given an empty string", function()
+            value, err = keychain:decrypt("")
+            assert.is_nil(value)
+            assert.is_nil(err)
+        end)
         it("fails when given a non-string", function()
-            assert.has.errors(function() keychain:decrypt({}) end)
+            value, err = keychain:decrypt({})
+            assert.is_nil(value)
+            assert.is_not_nil(err)
         end)
         it("requires cipher-text that is multiple of segment_size", function()
             local segment_byte_size = segment_size / 8
             local ciphertext = "\0"
             while (#ciphertext <= 64) do
+                value, err = keychain:decrypt(ciphertext)
                 if (#ciphertext % segment_byte_size == 0) then
-                    assert.has_no.errors(function()
-                        keychain:decrypt(ciphertext)
-                    end)
+                    assert.is_not_nil(value)
+                    assert.is_nil(err)
                 else
-                    assert.has.errors(function()
-                        keychain:decrypt(ciphertext)
-                    end)
+                    assert.is_nil(value)
+                    assert.is_not_nil(err)
                 end
                 ciphertext = ciphertext .. "\0"
                 keychain:reset()

--- a/spec/cfb_spec.lua
+++ b/spec/cfb_spec.lua
@@ -68,26 +68,31 @@ describe("#CFB", function()
     describe("encryption", function()
         local keychain
         local segment_size = 32
+        local value, err
         setup(function()
             keychain = blowfish.new(MODE, KEY, IV, segment_size)
         end)
-        it("returns nil when given an empty string",
-           function() assert.equal(nil, keychain:encrypt("")) end)
+        it("returns nil when given an empty string", function()
+            value, err = keychain:encrypt("")
+            assert.is_nil(value)
+            assert.is_nil(err)
+        end)
         it("fails when given a non-string", function()
-            assert.has.errors(function() keychain:encrypt({}) end)
+            value, err = keychain:encrypt({})
+            assert.is_nil(value)
+            assert.is_not_nil(err)
         end)
         it("requires message that is multiple of segment_size", function()
             local segment_byte_size = segment_size / 8
             local message = "a"
             while (#message <= 64) do
+                value, err = keychain:encrypt(message)
                 if (#message % segment_byte_size == 0) then
-                    assert.has_no.errors(function()
-                        keychain:encrypt(message)
-                    end)
+                    assert.is_not_nil(value)
+                    assert.is_nil(err)
                 else
-                    assert.has.errors(function()
-                        keychain:encrypt(message)
-                    end)
+                    assert.is_nil(value)
+                    assert.is_not_nil(err)
                 end
                 message = message .. "b"
                 keychain:reset()

--- a/spec/ecb_spec.lua
+++ b/spec/ecb_spec.lua
@@ -80,23 +80,28 @@ describe("#ECB", function()
 
     describe("decryption", function()
         local keychain
+        local value, err
         setup(function() keychain = blowfish.new(MODE, KEY) end)
-        it("returns nil when given an empty string",
-           function() assert.equal(nil, keychain:decrypt("")) end)
+        it("returns nil when given an empty string", function()
+            value, err = keychain:decrypt("")
+            assert.is_nil(value)
+            assert.is_nil(err)
+        end)
         it("fails when given a non-string", function()
-            assert.has.errors(function() keychain:decrypt({}) end)
+            value, err = keychain:decrypt({})
+            assert.is_nil(value)
+            assert.is_not_nil(err)
         end)
         it("requires cipher-text that is multiple of eight bytes", function()
             local ciphertext = "\0"
             while (#ciphertext <= 64) do
+                value, err = keychain:decrypt(ciphertext)
                 if (#ciphertext % 8 == 0) then
-                    assert.has_no.errors(function()
-                        keychain:decrypt(ciphertext)
-                    end)
+                    assert.is_not_nil(value)
+                    assert.is_nil(err)
                 else
-                    assert.has.errors(function()
-                        keychain:decrypt(ciphertext)
-                    end)
+                    assert.is_nil(value)
+                    assert.is_not_nil(err)
                 end
                 ciphertext = ciphertext .. "\0"
                 keychain:reset()

--- a/spec/ecb_spec.lua
+++ b/spec/ecb_spec.lua
@@ -49,23 +49,28 @@ describe("#ECB", function()
 
     describe("encryption", function()
         local keychain
+        local value, err
         setup(function() keychain = blowfish.new(MODE, KEY) end)
-        it("returns nil when given an empty string",
-           function() assert.equal(nil, keychain:encrypt("")) end)
+        it("returns nil when given an empty string", function()
+            value, err = keychain:encrypt("")
+            assert.is_nil(value)
+            assert.is_nil(value)
+        end)
         it("fails when given a non-string", function()
-            assert.has.errors(function() keychain:encrypt({}) end)
+            value, err = keychain:encrypt({})
+            assert.is_nil(value)
+            assert.is_not_nil(err)
         end)
         it("requires message that is multiple of eight bytes", function()
             local message = "a"
             while (#message <= 64) do
+                value, err = keychain:encrypt(message)
                 if (#message % 8 == 0) then
-                    assert.has_no.errors(function()
-                        keychain:encrypt(message)
-                    end)
+                    assert.is_not_nil(value)
+                    assert.is_nil(err)
                 else
-                    assert.has.errors(function()
-                        keychain:encrypt(message)
-                    end)
+                    assert.is_nil(value)
+                    assert.is_not_nil(err)
                 end
                 message = message .. "b"
                 keychain:reset()

--- a/spec/ofb_spec.lua
+++ b/spec/ofb_spec.lua
@@ -71,11 +71,17 @@ describe("#OFB", function()
 
     describe("decryption", function()
         local keychain
+        local value, err
         setup(function() keychain = blowfish.new(MODE, KEY, IV) end)
-        it("returns nil when given an empty string",
-           function() assert.equal(nil, keychain:decrypt("")) end)
+        it("returns nil when given an empty string", function()
+            value, err = keychain:decrypt("")
+            assert.is_nil(value)
+            assert.is_nil(err)
+        end)
         it("fails when given a non-string", function()
-            assert.has.errors(function() keychain:decrypt({}) end)
+            value, err = keychain:decrypt({})
+            assert.is_nil(value)
+            assert.is_not_nil(err)
         end)
     end)
 

--- a/spec/ofb_spec.lua
+++ b/spec/ofb_spec.lua
@@ -55,11 +55,17 @@ describe("#OFB", function()
 
     describe("encryption", function()
         local keychain
+        local value, err
         setup(function() keychain = blowfish.new(MODE, KEY, IV) end)
-        it("returns nil when given an empty string",
-           function() assert.equal(nil, keychain:encrypt("")) end)
+        it("returns nil when given an empty string", function()
+            value, err = keychain:encrypt("")
+            assert.is_nil(value)
+            assert.is_nil(err)
+        end)
         it("fails when given a non-string", function()
-            assert.has.errors(function() keychain:encrypt({}) end)
+            value, err = keychain:encrypt({})
+            assert.is_nil(value)
+            assert.is_not_nil(err)
         end)
     end)
 


### PR DESCRIPTION
This PR changes the encrypt and decrypt method from raising errors to returning value & error.  The latter is simply more amenable to writing lua code since it doesn't require clunky protected call syntax.  The initialization function still raises errors since giving it bad data is most likely a configuration error; encrypt/decrypt errors are data errors (if that makes any sense).